### PR TITLE
Updates to php 8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 .php_cs
 .php_cs.cache
+.phpunit.cache
 .phpunit.result.cache
 build
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "phpunit/phpunit": "^9.5"
+        "php": "^8.1",
+        "phpunit/phpunit": "^10.0"
     },
     "require-dev": {
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,39 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-    backupGlobals="false"
-    backupStaticAttributes="false"
-    bootstrap="vendor/autoload.php"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnFailure="false"
-    executionOrder="random"
-    failOnWarning="true"
-    failOnRisky="true"
-    failOnEmptyTestSuite="true"
-    beStrictAboutOutputDuringTests="true"
-    verbose="true"
->
-    <testsuites>
-        <testsuite name="HollyIT Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" executionOrder="random" failOnWarning="true" failOnRisky="true" failOnEmptyTestSuite="true" beStrictAboutOutputDuringTests="true" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="HollyIT Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <report>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
 </phpunit>

--- a/src/TokenReplacer.php
+++ b/src/TokenReplacer.php
@@ -307,7 +307,7 @@ class TokenReplacer
                 if (str_contains($matches[1][$key], ':')) {
                     list($token, $args) = explode(':', $matches[1][$key], 2);
                 }
-                $results = $this->doTransformation(trim($token), trim($args));
+                $results = $this->doTransformation(trim($token), trim($args ?? ''));
 
                 // Let our callback to any alterations if set.
                 if (is_callable($this->replaceCallback)) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,7 @@ namespace HollyIT\TokenReplace\Tests;
 
 class TestCase extends \PHPUnit\Framework\TestCase
 {
-    public function test()
+    protected function setUp(): void
     {
         \HollyIT\TokenReplace\TokenReplacer::$defaultTransformers = [
             'date' => \HollyIT\TokenReplace\Transformers\DateTransformer::class,

--- a/tests/Transformers/ArrayTransformerTest.php
+++ b/tests/Transformers/ArrayTransformerTest.php
@@ -9,7 +9,7 @@ use HollyIT\TokenReplace\Transformers\ArrayTransformer;
 class ArrayTransformerTest extends TestCase
 {
     /** @test **/
-    public function test_it_extracts_items_from_an_array()
+    public function it_extracts_items_from_an_array()
     {
         $str = 'The quick brown {{animal:jumper}} jumped over the lazy {{animal:target}}';
         $transformer = TokenReplacer::from($str)

--- a/tests/Transformers/ArrayTransformerTest.php
+++ b/tests/Transformers/ArrayTransformerTest.php
@@ -8,8 +8,8 @@ use HollyIT\TokenReplace\Transformers\ArrayTransformer;
 
 class ArrayTransformerTest extends TestCase
 {
-    /** @test * */
-    public function it_extracts_items_from_an_array()
+    /** @test **/
+    public function test_it_extracts_items_from_an_array()
     {
         $str = 'The quick brown {{animal:jumper}} jumped over the lazy {{animal:target}}';
         $transformer = TokenReplacer::from($str)
@@ -21,7 +21,7 @@ class ArrayTransformerTest extends TestCase
         $this->assertEquals('The quick brown fox jumped over the lazy dog', $transformer->transform());
     }
 
-    /** @test * */
+    /** @test **/
     public function it_removes_missing_array_values()
     {
         $str = 'The quick brown {{animal:jumper}} jumped over the lazy {{animal:target}}';

--- a/tests/Transformers/ClosureTransformerTest.php
+++ b/tests/Transformers/ClosureTransformerTest.php
@@ -6,7 +6,7 @@ use HollyIT\TokenReplace\Tests\TestCase;
 
 class ClosureTransformerTest extends TestCase
 {
-    /** @test * */
+    /** @test **/
     public function it_transforms_via_closures()
     {
         $transformer = new \HollyIT\TokenReplace\TokenReplacer('with {{ test1:options }} and without {{ test2 }}');

--- a/tests/Transformers/DateTransformerTest.php
+++ b/tests/Transformers/DateTransformerTest.php
@@ -8,7 +8,7 @@ use HollyIT\TokenReplace\Transformers\DateTransformer;
 
 class DateTransformerTest extends TestCase
 {
-    /** @test */
+    /** @test **/
     public function it_transforms_a_date()
     {
         $transformer = new \HollyIT\TokenReplace\TokenReplacer('replace a {{ date:m }}/{{ date:d }}/{{ date:y }} date token');
@@ -20,7 +20,7 @@ class DateTransformerTest extends TestCase
             ]) . ' date token', (string) $transformer);
     }
 
-    /** @test * */
+    /** @test **/
     public function it_requires_a_format_option()
     {
         $transformer = new \HollyIT\TokenReplace\TokenReplacer('{{ date }}');

--- a/tests/Transformers/FileTransformerTest.php
+++ b/tests/Transformers/FileTransformerTest.php
@@ -8,7 +8,7 @@ use HollyIT\TokenReplace\Transformers\FileTransformer;
 
 class FileTransformerTest extends TestCase
 {
-    /** @test * */
+    /** @test **/
     public function is_extract_from_a_file_path()
     {
         $path = '/home/me/test.txt';

--- a/tests/Transformers/ObjectTransformerTest.php
+++ b/tests/Transformers/ObjectTransformerTest.php
@@ -8,7 +8,7 @@ use HollyIT\TokenReplace\Transformers\ObjectTransformer;
 
 class ObjectTransformerTest extends TestCase
 {
-    /** @test * */
+    /** @test **/
     public function it_extracts_items_from_an_array()
     {
         $str = 'The quick brown {{animal:jumper}} jumped over the lazy {{animal:target}}';

--- a/tests/Transformers/UrlTransformerTest.php
+++ b/tests/Transformers/UrlTransformerTest.php
@@ -8,7 +8,7 @@ use HollyIT\TokenReplace\Transformers\UrlTransformer;
 
 class UrlTransformerTest extends TestCase
 {
-    /** @test * */
+    /** @test **/
     public function is_extract_from_a_file_path()
     {
         $url = 'https://example.com/index.html';


### PR DESCRIPTION
This PR updates the token-replacer tool to use PHP 8.1 which is what Laravel 10.x requires as a minimum.

Thanks for this great package!